### PR TITLE
system.xml Typo Fixes & Encrypt Password

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,7 +14,7 @@
             <class>separator-top</class>
             <label>Email Advanced</label>
             <tab>fruitcake</tab>
-            <resource>Fruitcake_EmailAdvancedConfig::smpt</resource>
+            <resource>Fruitcake_EmailAdvancedConfig::smtp</resource>
             <group id="smtp" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                 <label>SMTP Configuration</label>
                 <field id="transport" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -47,7 +47,8 @@
                 </field>
                 <field id="password" translate="label comment" type="text" sortOrder="102" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Password</label>
-                    <comment>Username</comment>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <comment>Password</comment>
                     <depends>
                         <field id="transport">smtp</field>
                     </depends>


### PR DESCRIPTION
Fixes typo of "smpt" for config resource, "Username" as comment for Password field, and sets the correct backend model to encrypt passwords - Closes open issue #1 