### PR TITLE
Fixes Configuration Typo & Begin encrypting passwords

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -2,16 +2,31 @@
 
 namespace Fruitcake\EmailAdvancedConfig\Helper;
 
-
 use Fruitcake\EmailAdvancedConfig\Model\Config\Source\SmtpTransportType;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\ScopeInterface;
-
+use Magento\Framework\Encryption\EncryptorInterface;
 
 class Data extends AbstractHelper
 {
     const CONFIG_PATH = 'fruitcake_email_advanced/';
+
+    /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
+     * @param Context $context
+     */
+    public function __construct(
+        Context $context,
+        EncryptorInterface $encryptor
+    ) {
+        parent::__construct($context);
+        $this->encryptor = $encryptor;
+    }
 
     public function isEnabled(): bool
     {
@@ -25,6 +40,10 @@ class Data extends AbstractHelper
      */
     public function getConfig($code = '')
     {
-        return $this->scopeConfig->getValue(self::CONFIG_PATH . $code, ScopeInterface::SCOPE_STORE, null);
+        $value = $this->scopeConfig->getValue(self::CONFIG_PATH . $code, ScopeInterface::SCOPE_STORE, null);
+
+        return ($code === 'smtp/password')
+            ? $this->encryptor->decrypt($value)
+            : $value;
     }
 }

--- a/Setup/Module/UpgradeData.php
+++ b/Setup/Module/UpgradeData.php
@@ -57,9 +57,8 @@ class UpgradeData implements UpgradeDataInterface
     {
         if (version_compare($context->getVersion(), '1.0.1') < 0) {
             $passwordPath = 'fruitcake_email_advanced/smtp/password';
-            $password = $this->scopeConfig->getValue($passwordPath, ScopeInterface::SCOPE_STORE);
-
-            if ($password && !$this->encryptor->decrypt($password)) {
+            
+            if ($password = $this->scopeConfig->getValue($passwordPath, ScopeInterface::SCOPE_STORE)) {
                 $this->configWriter->save($passwordPath, $this->encryptor->encrypt($password));
             }
         }

--- a/Setup/Module/UpgradeData.php
+++ b/Setup/Module/UpgradeData.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Fruitcake\EmailAdvancedConfig\Setup\Module;
+
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class UpgradeData implements UpgradeDataInterface
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
+     * @param ScopeConfigInterface $scopeConfig
+     * @param WriterInterface $configWriter
+     * @param EncryptorInterface $encryptor
+     */
+    public function __construct
+    (
+        ScopeConfigInterface $scopeConfig,
+        WriterInterface $configWriter,
+        EncryptorInterface $encryptor
+    )
+    {
+        $this->scopeConfig = $scopeConfig;
+        $this->configWriter = $configWriter;
+        $this->encryptor = $encryptor;
+    }
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     * @param ModuleContextInterface $context
+     * @return void
+     */
+    public function upgrade
+    (
+        ModuleDataSetupInterface $setup,
+        ModuleContextInterface $context
+    )
+    {
+        if (version_compare($context->getVersion(), '1.0.1') > 0) {
+            $passwordPath = 'fruitcake_email_advanced/smtp/password';
+            $password = $this->scopeConfig->getValue($passwordPath, ScopeInterface::SCOPE_STORE);
+
+            if ($password && !$this->encryptor->decrypt($password)) {
+                $this->configWriter->save($passwordPath, $this->encryptor->encrypt($password));
+            }
+        }
+    }
+}

--- a/Setup/Module/UpgradeData.php
+++ b/Setup/Module/UpgradeData.php
@@ -55,7 +55,7 @@ class UpgradeData implements UpgradeDataInterface
         ModuleContextInterface $context
     )
     {
-        if (version_compare($context->getVersion(), '1.0.1') > 0) {
+        if (version_compare($context->getVersion(), '1.0.1') < 0) {
             $passwordPath = 'fruitcake_email_advanced/smtp/password';
             $password = $this->scopeConfig->getValue($passwordPath, ScopeInterface::SCOPE_STORE);
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,7 +14,7 @@
             <class>separator-top</class>
             <label>Email Advanced</label>
             <tab>fruitcake</tab>
-            <resource>Fruitcake_EmailAdvancedConfig::smpt</resource>
+            <resource>Fruitcake_EmailAdvancedConfig::smtp</resource>
             <group id="smtp" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                 <label>SMTP Configuration</label>
                 <field id="transport" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -47,7 +47,8 @@
                 </field>
                 <field id="password" translate="label comment" type="text" sortOrder="102" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Password</label>
-                    <comment>Username</comment>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <comment>Password</comment>
                     <depends>
                         <field id="transport">smtp</field>
                     </depends>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Fruitcake_EmailAdvancedConfig" setup_version="1.0.0">
+    <module name="Fruitcake_EmailAdvancedConfig" setup_version="1.0.1">
         <sequence>
             <module name="Magento_Email"/>
         </sequence>


### PR DESCRIPTION
Fixes typo of "smpt" for config resource, "Username" as comment for Password field, and sets the correct backend model to encrypt passwords - Closes open issue https://github.com/fruitcake/magento2-email-advanced-config/issues/1

Existing passwords will be encrypted with setup:upgrade in order to not break existing users' configurations